### PR TITLE
Avoid bright colours in default menus

### DIFF
--- a/lib/touchbar-buttons.js
+++ b/lib/touchbar-buttons.js
@@ -82,7 +82,6 @@ const searchButtons = [
 const mainButtons = {
   'commandPalette': new TouchBarButton({
     label: '🎨',
-    backgroundColor: '#ffef81',
     click: () => {
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'command-palette:toggle')
     }
@@ -102,7 +101,6 @@ const mainButtons = {
   }),
   'git': new TouchBarButton({
     label: 'Git',
-    backgroundColor: '#679de4',
     click: () => {
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'github:toggle-git-tab')
     }


### PR DESCRIPTION
The colours are very bright and distracting. They are fine while interacting with the menus, but in the default state it's better they merge in with the keyboard.