### PR TITLE
Update package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-touchbar",
   "main": "./lib/atom-touchbar",
   "version": "0.3.0",
-  "description": "Adds MacBook touchbar to Atom",
+  "description": "Adds Touch Bar support to Atom on supported MacBooks",
   "keywords": [],
   "repository": "https://github.com/tgds/atom-touchbar",
   "license": "MIT",


### PR DESCRIPTION
This is because when searching from packages within Atom, this is the most prominent way of checking if a package is useful.